### PR TITLE
feat: Update with the new withAuth API, extract the custom verifyWith…

### DIFF
--- a/pages/api/stateless/_middleware.js
+++ b/pages/api/stateless/_middleware.js
@@ -1,4 +1,4 @@
-import { requireSession } from '@clerk/nextjs/edge';
+import { withAuth } from '@clerk/nextjs/edge';
 import { withTimer, endTimer, timerResult } from '../../../utils/timer';
 
 // The handler should return a Response object
@@ -7,7 +7,7 @@ const handler = async req => {
 
   return new Response(
     JSON.stringify({
-      ...req.session,
+      userId: req.auth.userId,
       ...timerResult(req),
     }),
     {
@@ -19,4 +19,4 @@ const handler = async req => {
   );
 };
 
-export default withTimer(requireSession(handler));
+export default withTimer(withAuth(handler));


### PR DESCRIPTION
## Note
Will merge when v3 is stable and updated.

## Update

Update the demo to v3 of the API.
- Change to v3 `withAuth` API
- Extract the `verifyWithNetwork` function as it is a non-standard.